### PR TITLE
Adds image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ An iOS toast framework.
 
 ## Styles
 
-Toasts come in three styles:
+Toasts come in four styles:
 
 * Standard
+* Image
 * Indeterminate
 * Progress
 
@@ -22,6 +23,23 @@ To enqueue a standard toast with a subtitle:
 
 ```swift
 Butter.enqueue(.init(title: "This is a toast", subtitle: "Hello"))
+```
+
+### Image
+
+To enqueue a image toast:
+
+```swift
+let image: UIImage = someUIImage()
+Butter.enqueue(.init(title: "An image!", style: .image(image)))
+```
+
+By default, the image is masked to a circle with a radius of 12pt. This can be disabled:
+
+```swift
+Butter.enqueue(.init(
+  title: "An unmasked image!", 
+  style: .image(image, shouldMaskToCircle: false)))
 ```
 
 ### Indeterminate

--- a/Sources/Butter/Toast.swift
+++ b/Sources/Butter/Toast.swift
@@ -15,6 +15,9 @@ public enum Style: Hashable {
   /// A toast that is automatically dismissed after a short period of time.
   case standard
 
+  /// A toast that includes an image and is automatically dismissed after a short period of time.
+  case image(UIImage, shouldMaskToCircle: Bool = true)
+
   /// A toast that includes an indeterminate progress indicator. This toast is not automatically dismissed.
   case indeterminate
 
@@ -86,11 +89,11 @@ public struct Toast: Identifiable {
 
   /// Indicates whether the toast should be dismissed when tapped.
   ///
-  /// Returns `true` for `.standard` toasts. Returns `false` for `.indeterminate` toasts. Returns `true` for `.progress`
-  /// toasts if the progress `isFinished`, false otherwise.
+  /// Returns `true` for `.standard` and `.image` toasts. Returns `false` for `.indeterminate` toasts. Returns `true`
+  /// for `.progress` toasts if the progress `isFinished`, false otherwise.
   public var shouldDismissWhenTapped: Bool {
     switch style {
-    case .standard:
+    case .standard, .image:
       return true
     case .indeterminate:
       return false
@@ -103,7 +106,7 @@ public struct Toast: Identifiable {
   /// automatically dismissed.
   public var duration: TimeInterval? {
     switch style {
-    case .standard:
+    case .standard, .image:
       return Self.duration
     case .indeterminate:
       return nil

--- a/Sources/Butter/ToastView.swift
+++ b/Sources/Butter/ToastView.swift
@@ -5,12 +5,16 @@ class ToastView: UIView {
   static let minimumWidth: CGFloat = 194
   static let height: CGFloat = 50
 
+  /// The width and height of the image.
+  static let imageSize: CGFloat = 24
+
   private let contentView = UIView()
   private var visualEffectView: UIVisualEffectView!
   private let titleLabel = UILabel()
   private let subtitleLabel = UILabel()
   private let activityIndicatorView = UIActivityIndicatorView(style: .medium)
   private let circularProgressView = CircularProgressView()
+  private let imageView = UIImageView()
   private var tapGestureRecognizer: UITapGestureRecognizer!
   private var leadingItemStackView = UIStackView()
 
@@ -60,10 +64,12 @@ class ToastView: UIView {
       case .standard:
         activityIndicatorView.isHidden = true
         circularProgressView.isHidden = true
+        imageView.isHidden = true
       case .indeterminate:
         activityIndicatorView.isHidden = false
         activityIndicatorView.startAnimating()
         circularProgressView.isHidden = true
+        imageView.isHidden = true
       case let .progress(progress, tintColor):
         circularProgressView.tintColor = tintColor
         circularProgressView.onFinished = { [weak self] in
@@ -73,6 +79,14 @@ class ToastView: UIView {
         activityIndicatorView.isHidden = true
         circularProgressView.isHidden = false
         circularProgressView.observedProgress = progress
+        imageView.isHidden = true
+      case let .image(image, shouldMaskToCircle):
+        activityIndicatorView.isHidden = true
+        circularProgressView.isHidden = true
+        imageView.isHidden = false
+
+        imageView.image = image
+        imageView.layer.cornerRadius = shouldMaskToCircle ? Self.imageSize / 2.0 : 0
       }
     }
   }
@@ -126,6 +140,7 @@ class ToastView: UIView {
 
     leadingItemStackView.addArrangedSubview(activityIndicatorView)
     leadingItemStackView.addArrangedSubview(circularProgressView)
+    leadingItemStackView.addArrangedSubview(imageView)
 
     visualEffectView.translatesAutoresizingMaskIntoConstraints = false
     visualEffectView.constrainEdgesEqualToSuperview()
@@ -156,6 +171,11 @@ class ToastView: UIView {
     NSLayoutConstraint.activate([
       leadingItemStackView.centerXAnchor.constraint(equalTo: contentView.leftAnchor, constant: Self.height / 2),
       leadingItemStackView.centerYAnchor.constraint(equalTo: contentView.topAnchor, constant: Self.height / 2)
+    ])
+
+    NSLayoutConstraint.activate([
+      imageView.widthAnchor.constraint(equalToConstant: Self.imageSize),
+      imageView.heightAnchor.constraint(equalToConstant: Self.imageSize)
     ])
 
     titleLabel.textColor = .label


### PR DESCRIPTION
Adds a new `.image` toast type. Intended to support this style Toast:

<img width="526" alt="image" src="https://user-images.githubusercontent.com/728791/129148153-5c7b6b0c-882b-4767-8801-6055b5d4d0fa.png">
